### PR TITLE
Implement fixture CSV export skeleton

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "leben-vocab"
+version = "0.1.0"
+description = "Export Leben in Deutschland vocabulary study CSVs."
+readme = "plans/2026-04-26-leben-vocab-python-project.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=8"]
+
+[project.scripts]
+leben-vocab = "leben_vocab.cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/leben_vocab"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/leben_vocab/__init__.py
+++ b/src/leben_vocab/__init__.py
@@ -1,0 +1,5 @@
+"""Leben Vocab package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/src/leben_vocab/answers.py
+++ b/src/leben_vocab/answers.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AnswerKey:
+    question_id: str
+    correct_option_id: str
+
+
+class FixtureAnswerProvider:
+    def load_answer_keys(self) -> list[AnswerKey]:
+        return [
+            AnswerKey(question_id="1", correct_option_id="a"),
+            AnswerKey(question_id="BE-1", correct_option_id="a"),
+        ]

--- a/src/leben_vocab/cli.py
+++ b/src/leben_vocab/cli.py
@@ -1,0 +1,26 @@
+import argparse
+from pathlib import Path
+
+from leben_vocab.export import export_fixture_vocabulary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="leben-vocab")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    export_parser = subparsers.add_parser("export")
+    export_parser.add_argument("--state", default="Berlin")
+    export_parser.add_argument("--target-lang", required=True)
+    export_parser.add_argument("--output", required=True, type=Path)
+
+    args = parser.parse_args(argv)
+    if args.command == "export":
+        export_fixture_vocabulary(
+            state=args.state,
+            target_language=args.target_lang,
+            output_path=args.output,
+        )
+        return 0
+
+    parser.error(f"Unsupported command: {args.command}")
+    return 2

--- a/src/leben_vocab/corpus.py
+++ b/src/leben_vocab/corpus.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AnswerOption:
+    id: str
+    text: str
+
+
+@dataclass(frozen=True)
+class Question:
+    id: str
+    state: str | None
+    text: str
+    options: tuple[AnswerOption, ...]
+
+
+class FixtureCorpusProvider:
+    def load_questions(self, state: str) -> list[Question]:
+        return [
+            Question(
+                id="1",
+                state=None,
+                text="Deutschland ist eine Demokratie.",
+                options=(
+                    AnswerOption(id="a", text="Demokratie"),
+                    AnswerOption(id="b", text="Monarchie"),
+                ),
+            ),
+            Question(
+                id="BE-1",
+                state=state,
+                text="Berlin hat ein Parlament.",
+                options=(
+                    AnswerOption(id="a", text="Wahl"),
+                    AnswerOption(id="b", text="See"),
+                ),
+            ),
+        ]

--- a/src/leben_vocab/csv_export.py
+++ b/src/leben_vocab/csv_export.py
@@ -1,0 +1,39 @@
+import csv
+from pathlib import Path
+
+from leben_vocab.vocabulary import VocabularyItem
+
+CSV_COLUMNS = [
+    "word",
+    "type",
+    "display",
+    "translation",
+    "example",
+    "example_source",
+    "question_id",
+    "count",
+    "target_language",
+]
+
+
+def write_vocabulary_csv(
+    items: list[VocabularyItem], target_language: str, output_path: Path
+) -> None:
+    rows = sorted(items, key=lambda item: (-item.count, item.word))
+    with output_path.open("w", newline="", encoding="utf-8") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        for item in rows:
+            writer.writerow(
+                {
+                    "word": item.word,
+                    "type": item.kind,
+                    "display": item.display,
+                    "translation": item.translation,
+                    "example": item.example,
+                    "example_source": item.example_source,
+                    "question_id": item.question_id,
+                    "count": item.count,
+                    "target_language": target_language,
+                }
+            )

--- a/src/leben_vocab/export.py
+++ b/src/leben_vocab/export.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from leben_vocab.answers import FixtureAnswerProvider
+from leben_vocab.corpus import FixtureCorpusProvider
+from leben_vocab.csv_export import write_vocabulary_csv
+from leben_vocab.translation import FixtureTranslationProvider
+from leben_vocab.vocabulary import extract_vocabulary
+
+
+def export_fixture_vocabulary(
+    state: str,
+    target_language: str,
+    output_path: Path,
+    corpus_provider: FixtureCorpusProvider | None = None,
+    answer_provider: FixtureAnswerProvider | None = None,
+    translation_provider: FixtureTranslationProvider | None = None,
+) -> None:
+    corpus_provider = corpus_provider or FixtureCorpusProvider()
+    answer_provider = answer_provider or FixtureAnswerProvider()
+    translation_provider = translation_provider or FixtureTranslationProvider()
+
+    questions = corpus_provider.load_questions(state)
+    answer_keys = answer_provider.load_answer_keys()
+    items = extract_vocabulary(questions, answer_keys)
+    translated_items = [
+        item.with_translation(translation_provider.translate(item.word, target_language))
+        for item in items
+    ]
+    write_vocabulary_csv(translated_items, target_language, output_path)

--- a/src/leben_vocab/translation.py
+++ b/src/leben_vocab/translation.py
@@ -1,0 +1,8 @@
+class FixtureTranslationProvider:
+    _translations = {
+        ("demokratie", "en"): "democracy",
+        ("wahl", "en"): "election",
+    }
+
+    def translate(self, word: str, target_language: str) -> str:
+        return self._translations.get((word, target_language), f"{word}-{target_language}")

--- a/src/leben_vocab/vocabulary.py
+++ b/src/leben_vocab/vocabulary.py
@@ -1,0 +1,63 @@
+from dataclasses import dataclass, replace
+
+from leben_vocab.answers import AnswerKey
+from leben_vocab.corpus import Question
+
+
+@dataclass(frozen=True)
+class VocabularyItem:
+    word: str
+    kind: str
+    display: str
+    translation: str
+    example: str
+    example_source: str
+    question_id: str
+    count: int
+
+    def with_translation(self, translation: str) -> "VocabularyItem":
+        return replace(self, translation=translation)
+
+
+def extract_vocabulary(
+    questions: list[Question], answer_keys: list[AnswerKey]
+) -> list[VocabularyItem]:
+    correct_options = {
+        answer.question_id: answer.correct_option_id for answer in answer_keys
+    }
+    counts: dict[str, VocabularyItem] = {}
+
+    for question in questions:
+        correct_option_id = correct_options[question.id]
+        correct_option = next(
+            option for option in question.options if option.id == correct_option_id
+        )
+        fixture_words = _fixture_words(question.text, correct_option.text)
+        for word in fixture_words:
+            existing = counts.get(word)
+            if existing is None:
+                counts[word] = VocabularyItem(
+                    word=word,
+                    kind="noun",
+                    display=word.capitalize(),
+                    translation="",
+                    example=question.text,
+                    example_source="fixture",
+                    question_id=question.id,
+                    count=1,
+                )
+            else:
+                counts[word] = replace(existing, count=existing.count + 1)
+
+    return list(counts.values())
+
+
+def _fixture_words(question_text: str, correct_answer_text: str) -> list[str]:
+    texts = [question_text.lower(), correct_answer_text.lower()]
+    words: list[str] = []
+    for text in texts:
+        if "demokratie" in text:
+            words.append("demokratie")
+        if "wahl" in text:
+            words.append("wahl")
+    return words

--- a/tests/test_cli_export.py
+++ b/tests/test_cli_export.py
@@ -1,0 +1,62 @@
+import csv
+
+from leben_vocab.cli import main
+
+
+def test_export_command_writes_berlin_english_fixture_csv(tmp_path):
+    output_path = tmp_path / "words_en.csv"
+
+    exit_code = main(
+        [
+            "export",
+            "--state",
+            "Berlin",
+            "--target-lang",
+            "en",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    assert exit_code == 0
+    with output_path.open(newline="", encoding="utf-8") as csv_file:
+        reader = csv.DictReader(csv_file)
+        rows = list(reader)
+
+    assert reader.fieldnames == [
+        "word",
+        "type",
+        "display",
+        "translation",
+        "example",
+        "example_source",
+        "question_id",
+        "count",
+        "target_language",
+    ]
+    assert rows
+    assert {row["target_language"] for row in rows} == {"en"}
+
+
+def test_export_command_sorts_fixture_rows_by_count_descending(tmp_path):
+    output_path = tmp_path / "words_en.csv"
+
+    main(
+        [
+            "export",
+            "--state",
+            "Berlin",
+            "--target-lang",
+            "en",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    with output_path.open(newline="", encoding="utf-8") as csv_file:
+        rows = list(csv.DictReader(csv_file))
+
+    assert [(row["word"], row["count"]) for row in rows] == [
+        ("demokratie", "2"),
+        ("wahl", "1"),
+    ]

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -1,0 +1,23 @@
+import tomllib
+from pathlib import Path
+
+
+def test_project_declares_package_shape_and_console_entry_point():
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+
+    assert pyproject["project"]["name"] == "leben-vocab"
+    assert pyproject["project"]["scripts"]["leben-vocab"] == "leben_vocab.cli:main"
+    assert pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"] == [
+        "src/leben_vocab"
+    ]
+    assert "pytest>=8" in pyproject["project"]["optional-dependencies"]["dev"]
+
+
+def test_gitignore_excludes_local_environment_and_build_artifacts():
+    gitignore = Path(".gitignore").read_text(encoding="utf-8").splitlines()
+
+    assert ".env" in gitignore
+    assert ".venv" in gitignore
+    assert "build/" in gitignore
+    assert "dist/" in gitignore
+    assert ".pytest_cache/" in gitignore


### PR DESCRIPTION
Closes #2

## Summary
- add conventional Python package metadata and console entry point
- add fixture-backed export orchestration and CSV writer
- add CLI smoke and metadata contract tests

## Verification
- .venv/bin/python -m pytest
- .venv/bin/leben-vocab export --state Berlin --target-lang en --output <tmp>/words_en.csv