### PR TITLE
Parse official BAMF corpus selections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Export Leben in Deutschland vocabulary study CSVs."
 readme = "plans/2026-04-26-leben-vocab-python-project.md"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = ["pymupdf>=1.27"]
 
 [project.optional-dependencies]
 dev = ["pytest>=8"]

--- a/src/leben_vocab/corpus.py
+++ b/src/leben_vocab/corpus.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 class AnswerOption:
     id: str
     text: str
+    is_image_only: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/leben_vocab/official_corpus.py
+++ b/src/leben_vocab/official_corpus.py
@@ -1,0 +1,172 @@
+import re
+from pathlib import Path
+
+import pymupdf
+
+from leben_vocab.corpus import AnswerOption, Question
+
+STATE_CODES = {
+    "Baden-Württemberg": "BW",
+    "Bayern": "BY",
+    "Berlin": "BE",
+    "Brandenburg": "BB",
+    "Bremen": "HB",
+    "Hamburg": "HH",
+    "Hessen": "HE",
+    "Mecklenburg-Vorpommern": "MV",
+    "Niedersachsen": "NI",
+    "Nordrhein-Westfalen": "NW",
+    "Rheinland-Pfalz": "RP",
+    "Saarland": "SL",
+    "Sachsen": "SN",
+    "Sachsen-Anhalt": "ST",
+    "Schleswig-Holstein": "SH",
+    "Thüringen": "TH",
+}
+
+_TASK_RE = re.compile(r"^Aufgabe\s+(\d+)$")
+_PAGE_HEADER_RE = re.compile(r"^Seite\s+\d+\s+von\s+\d+$")
+_OPTION_MARKERS = ("", "□")
+
+
+def parse_official_questions(pdf_path: Path) -> list[Question]:
+    document = pymupdf.open(pdf_path)
+    questions: list[Question] = []
+    current_state: str | None = None
+    current_number: int | None = None
+    current_lines: list[str] = []
+
+    for page in document:
+        for raw_line in page.get_text("text").splitlines():
+            line = raw_line.strip()
+            if not line or _is_ignored_line(line):
+                continue
+
+            detected_state = _detect_state_heading(line)
+            if detected_state is not None:
+                if current_number is not None:
+                    questions.append(
+                        _build_question(current_number, current_state, current_lines)
+                    )
+                    current_number = None
+                    current_lines = []
+                current_state = detected_state
+                continue
+
+            task_match = _TASK_RE.match(line)
+            if task_match:
+                if current_number is not None:
+                    questions.append(
+                        _build_question(current_number, current_state, current_lines)
+                    )
+                current_number = int(task_match.group(1))
+                current_lines = []
+                continue
+
+            if current_number is not None:
+                current_lines.append(line)
+
+    if current_number is not None:
+        questions.append(_build_question(current_number, current_state, current_lines))
+
+    return questions
+
+
+def select_questions_for_state(
+    questions: list[Question], state: str = "Berlin"
+) -> list[Question]:
+    return [
+        question
+        for question in questions
+        if question.state is None or question.state == state
+    ]
+
+
+def _build_question(number: int, state: str | None, lines: list[str]) -> Question:
+    question_lines: list[str] = []
+    option_texts: list[str] = []
+    current_option_index: int | None = None
+    in_options = False
+
+    for line in lines:
+        option_text = _strip_option_marker(line)
+        if option_text is not None:
+            in_options = True
+            option_texts.append(option_text)
+            current_option_index = len(option_texts) - 1
+            continue
+
+        if in_options and current_option_index is not None:
+            option_texts[current_option_index] = (
+                f"{option_texts[current_option_index]} {line}".strip()
+            )
+            continue
+
+        if _is_image_label(line):
+            continue
+        question_lines.append(line)
+
+    question_id = str(number) if state is None else f"{STATE_CODES[state]}-{number}"
+    return Question(
+        id=question_id,
+        state=state,
+        text=" ".join(question_lines),
+        options=tuple(_build_options(option_texts, question_lines)),
+    )
+
+
+def _build_options(
+    option_texts: list[str], question_lines: list[str]
+) -> list[AnswerOption]:
+    option_ids = ["a", "b", "c", "d"]
+    image_only_options = _options_are_image_only(option_texts, question_lines)
+    options: list[AnswerOption] = []
+    for option_id, text in zip(option_ids, option_texts, strict=False):
+        options.append(
+            AnswerOption(
+                id=option_id,
+                text="" if image_only_options else text,
+                is_image_only=image_only_options,
+            )
+        )
+    return options
+
+
+def _strip_option_marker(line: str) -> str | None:
+    if not line.startswith(_OPTION_MARKERS):
+        return None
+    return line[1:].strip()
+
+
+def _detect_state_heading(line: str) -> str | None:
+    if not line.startswith("Fragen für"):
+        return None
+    for state in sorted(STATE_CODES, key=len, reverse=True):
+        if state in line:
+            return state
+    return None
+
+
+def _is_ignored_line(line: str) -> bool:
+    return (
+        line in {"Teil I", "Teil II", "Allgemeine Fragen"}
+        or _PAGE_HEADER_RE.match(line) is not None
+        or line.startswith("© ")
+    )
+
+
+def _is_image_label(line: str) -> bool:
+    return re.fullmatch(r"Bild\s+\d+", line) is not None
+
+
+def _options_are_image_only(
+    option_texts: list[str], question_lines: list[str]
+) -> bool:
+    if option_texts and all(_is_image_label(text) for text in option_texts):
+        return True
+    question_text = " ".join(question_lines)
+    return (
+        question_text.startswith("Welches Bundesland ist")
+        and bool(option_texts)
+        and all(text in {"1", "2", "3", "4"} for text in option_texts)
+    )

--- a/tests/test_official_corpus.py
+++ b/tests/test_official_corpus.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+from leben_vocab.official_corpus import (
+    parse_official_questions,
+    select_questions_for_state,
+)
+
+
+PDF_PATH = Path("lid2026.pdf")
+
+
+def test_official_pdf_parses_into_460_questions():
+    questions = parse_official_questions(PDF_PATH)
+
+    assert len(questions) == 460
+
+
+def test_general_questions_keep_bamf_numbering():
+    questions = parse_official_questions(PDF_PATH)
+    general = [question for question in questions if question.state is None]
+
+    assert len(general) == 300
+    assert general[0].id == "1"
+    assert general[-1].id == "300"
+
+
+def test_default_selection_returns_general_questions_plus_berlin():
+    questions = parse_official_questions(PDF_PATH)
+
+    selected = select_questions_for_state(questions)
+
+    assert len(selected) == 310
+    assert [question.id for question in selected[:3]] == ["1", "2", "3"]
+    assert [question.id for question in selected[-10:]] == [
+        "BE-1",
+        "BE-2",
+        "BE-3",
+        "BE-4",
+        "BE-5",
+        "BE-6",
+        "BE-7",
+        "BE-8",
+        "BE-9",
+        "BE-10",
+    ]
+
+
+def test_non_default_state_selection_is_not_hard_coded_to_berlin():
+    questions = parse_official_questions(PDF_PATH)
+
+    selected = select_questions_for_state(questions, state="Bayern")
+
+    assert len(selected) == 310
+    assert [question.id for question in selected[-10:]] == [
+        "BY-1",
+        "BY-2",
+        "BY-3",
+        "BY-4",
+        "BY-5",
+        "BY-6",
+        "BY-7",
+        "BY-8",
+        "BY-9",
+        "BY-10",
+    ]
+
+
+def test_hyphenated_state_selection_uses_the_full_state_name():
+    questions = parse_official_questions(PDF_PATH)
+
+    selected = select_questions_for_state(questions, state="Sachsen-Anhalt")
+
+    assert len(selected) == 310
+    assert [question.id for question in selected[-10:]] == [
+        "ST-1",
+        "ST-2",
+        "ST-3",
+        "ST-4",
+        "ST-5",
+        "ST-6",
+        "ST-7",
+        "ST-8",
+        "ST-9",
+        "ST-10",
+    ]
+
+
+def test_image_only_answer_options_do_not_fabricate_answer_text():
+    questions = parse_official_questions(PDF_PATH)
+    berlin_wappen = next(question for question in questions if question.id == "BE-1")
+
+    assert "Welches Wappen gehört" in berlin_wappen.text
+    assert [option.text for option in berlin_wappen.options] == ["", "", "", ""]
+    assert all(option.is_image_only for option in berlin_wappen.options)


### PR DESCRIPTION
Closes #3

## Summary
- add PyMuPDF-backed official corpus parsing for the committed BAMF PDF
- preserve general BAMF numbering and state-prefixed IDs for selected state questions
- support default Berlin and non-default state selection, including hyphenated state names
- mark image-only answer choices without fabricating option text

## Verification
- .venv/bin/python -m pytest
- git diff --check