### PR TITLE
Add answer provider matching audit

### DIFF
--- a/src/leben_vocab/answers.py
+++ b/src/leben_vocab/answers.py
@@ -1,4 +1,10 @@
 from dataclasses import dataclass
+import json
+import re
+from typing import Any, Callable
+from urllib.request import urlopen
+
+from leben_vocab.corpus import Question
 
 
 @dataclass(frozen=True)
@@ -7,9 +13,126 @@ class AnswerKey:
     correct_option_id: str
 
 
+@dataclass(frozen=True)
+class StructuredAnswer:
+    question_id: str
+    correct_option_id: str
+    question_text: str = ""
+
+
+class AnswerMatchingError(ValueError):
+    pass
+
+
 class FixtureAnswerProvider:
-    def load_answer_keys(self) -> list[AnswerKey]:
-        return [
-            AnswerKey(question_id="1", correct_option_id="a"),
-            AnswerKey(question_id="BE-1", correct_option_id="a"),
+    def __init__(self, answers: list[StructuredAnswer] | None = None) -> None:
+        self._answers = answers or [
+            StructuredAnswer(question_id="1", correct_option_id="a"),
+            StructuredAnswer(question_id="BE-1", correct_option_id="a"),
         ]
+
+    def load_answer_keys(self) -> list[StructuredAnswer]:
+        return self._answers
+
+
+class PinnedGitHubAnswerProvider:
+    SOURCE_URL = (
+        "https://raw.githubusercontent.com/leben-in-deutschland/"
+        "leben-in-deutschland-app/"
+        "b1832e7145080e0f70ebd680f24efc0933892e18/"
+        "src/web/data/question.json"
+    )
+
+    def __init__(
+        self,
+        source_url: str = SOURCE_URL,
+        fetch_json: Callable[[str], Any] | None = None,
+    ) -> None:
+        self.source_url = source_url
+        self._fetch_json = fetch_json or _fetch_json
+
+    def load_answer_keys(self) -> list[StructuredAnswer]:
+        records = self._fetch_json(self.source_url)
+        return [_structured_answer_from_record(record) for record in records]
+
+
+def match_answer_keys(
+    questions: list[Question], answers: list[StructuredAnswer]
+) -> list[AnswerKey]:
+    answers_by_id = {answer.question_id: answer for answer in answers}
+    answers_by_text = {
+        _normalize_question_text(answer.question_text): answer
+        for answer in answers
+        if answer.question_text
+    }
+    matches: list[AnswerKey] = []
+    missing_question_ids: list[str] = []
+
+    for question in questions:
+        answer = answers_by_id.get(question.id)
+        if answer is None:
+            answer = answers_by_text.get(_normalize_question_text(question.text))
+        if answer is None:
+            missing_question_ids.append(question.id)
+            continue
+        _ensure_option_exists(question, answer.correct_option_id)
+        matches.append(
+            AnswerKey(
+                question_id=question.id,
+                correct_option_id=answer.correct_option_id,
+            )
+        )
+
+    if missing_question_ids:
+        raise AnswerMatchingError(
+            "Unable to match correct answers; unmatched question ids: "
+            + ", ".join(missing_question_ids)
+        )
+
+    return matches
+
+
+def _ensure_option_exists(question: Question, option_id: str) -> None:
+    if not any(option.id == option_id for option in question.options):
+        raise AnswerMatchingError(
+            f"Question {question.id} references missing correct option {option_id!r}"
+        )
+
+
+def _normalize_question_text(text: str) -> str:
+    normalized = (
+        text.lower()
+        .replace("ä", "ae")
+        .replace("ö", "oe")
+        .replace("ü", "ue")
+        .replace("ß", "ss")
+    )
+    normalized = re.sub(r"[^a-z0-9]+", " ", normalized)
+    return " ".join(normalized.split())
+
+
+def _fetch_json(url: str) -> Any:
+    with urlopen(url, timeout=30) as response:
+        return json.load(response)
+
+
+def _structured_answer_from_record(record: dict[str, Any]) -> StructuredAnswer:
+    question_id = str(
+        record.get("num") or record.get("question_id") or record.get("id") or ""
+    )
+    correct_option_id = str(
+        record.get("solution")
+        or record.get("correct_option_id")
+        or record.get("answer")
+        or ""
+    ).lower()
+    question_text = str(record.get("question") or record.get("question_text") or "")
+    if not question_id or correct_option_id not in {"a", "b", "c", "d"}:
+        raise AnswerMatchingError(
+            f"Structured answer record is missing a usable id or answer: {record!r}"
+        )
+    return StructuredAnswer(
+        question_id=question_id,
+        correct_option_id=correct_option_id,
+        question_text=question_text,
+    )

--- a/src/leben_vocab/export.py
+++ b/src/leben_vocab/export.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from leben_vocab.answers import FixtureAnswerProvider
+from leben_vocab.answers import FixtureAnswerProvider, match_answer_keys
 from leben_vocab.corpus import FixtureCorpusProvider
 from leben_vocab.csv_export import write_vocabulary_csv
 from leben_vocab.translation import FixtureTranslationProvider
@@ -20,7 +20,7 @@ def export_fixture_vocabulary(
     translation_provider = translation_provider or FixtureTranslationProvider()
 
     questions = corpus_provider.load_questions(state)
-    answer_keys = answer_provider.load_answer_keys()
+    answer_keys = match_answer_keys(questions, answer_provider.load_answer_keys())
     items = extract_vocabulary(questions, answer_keys)
     translated_items = [
         item.with_translation(translation_provider.translate(item.word, target_language))

--- a/tests/test_answer_matching.py
+++ b/tests/test_answer_matching.py
@@ -1,0 +1,145 @@
+import pytest
+
+from leben_vocab.answers import (
+    AnswerKey,
+    AnswerMatchingError,
+    FixtureAnswerProvider,
+    PinnedGitHubAnswerProvider,
+    StructuredAnswer,
+    match_answer_keys,
+)
+from leben_vocab.corpus import AnswerOption, Question
+from leben_vocab.vocabulary import extract_vocabulary
+
+
+def test_answer_matching_prefers_official_question_numbers():
+    questions = [
+        Question(
+            id="42",
+            state=None,
+            text="Welche Partei ist im Deutschen Bundestag vertreten?",
+            options=(
+                AnswerOption(id="a", text="Partei A"),
+                AnswerOption(id="b", text="Partei B"),
+                AnswerOption(id="c", text="Partei C"),
+                AnswerOption(id="d", text="Partei D"),
+            ),
+        )
+    ]
+    provider = FixtureAnswerProvider(
+        [
+            StructuredAnswer(
+                question_id="42",
+                correct_option_id="c",
+                question_text="Third-party wording that must not be authoritative",
+            )
+        ]
+    )
+
+    matches = match_answer_keys(questions, provider.load_answer_keys())
+
+    assert matches == [AnswerKey(question_id="42", correct_option_id="c")]
+
+
+def test_answer_matching_falls_back_to_normalized_question_text():
+    questions = [
+        Question(
+            id="17",
+            state=None,
+            text="Wer wählt den Deutschen Bundestag?",
+            options=(
+                AnswerOption(id="a", text="die Bundesregierung"),
+                AnswerOption(id="b", text="das Volk"),
+                AnswerOption(id="c", text="der Bundesrat"),
+                AnswerOption(id="d", text="die Gerichte"),
+            ),
+        )
+    ]
+    provider = FixtureAnswerProvider(
+        [
+            StructuredAnswer(
+                question_id="third-party-17",
+                correct_option_id="b",
+                question_text="Wer waehlt den deutschen Bundestag",
+            )
+        ]
+    )
+
+    matches = match_answer_keys(questions, provider.load_answer_keys())
+
+    assert matches == [AnswerKey(question_id="17", correct_option_id="b")]
+
+
+def test_answer_matching_fails_with_audit_friendly_diagnostics():
+    questions = [
+        Question(
+            id="99",
+            state=None,
+            text="Welche Aufgabe hat der Bundesrat?",
+            options=(
+                AnswerOption(id="a", text="Option A"),
+                AnswerOption(id="b", text="Option B"),
+                AnswerOption(id="c", text="Option C"),
+                AnswerOption(id="d", text="Option D"),
+            ),
+        )
+    ]
+    provider = FixtureAnswerProvider(
+        [
+            StructuredAnswer(
+                question_id="not-99",
+                correct_option_id="a",
+                question_text="Eine andere Frage",
+            )
+        ]
+    )
+
+    with pytest.raises(AnswerMatchingError, match="unmatched question ids: 99"):
+        match_answer_keys(questions, provider.load_answer_keys())
+
+
+def test_pinned_github_provider_loads_only_correct_answer_letters():
+    requested_urls = []
+
+    def fetch_json(url):
+        requested_urls.append(url)
+        return [
+            {
+                "num": "1",
+                "question": "Third-party wording for matching fallback only",
+                "a": "Do not use this wording",
+                "b": "Do not use this wording either",
+                "solution": "b",
+            }
+        ]
+
+    provider = PinnedGitHubAnswerProvider(fetch_json=fetch_json)
+
+    assert provider.load_answer_keys() == [
+        StructuredAnswer(
+            question_id="1",
+            correct_option_id="b",
+            question_text="Third-party wording for matching fallback only",
+        )
+    ]
+    assert requested_urls == [PinnedGitHubAnswerProvider.SOURCE_URL]
+    assert "b1832e7145080e0f70ebd680f24efc0933892e18" in provider.SOURCE_URL
+
+
+def test_vocabulary_input_uses_correct_answer_and_excludes_distractors():
+    question = Question(
+        id="5",
+        state=None,
+        text="Eine neutrale Frage.",
+        options=(
+            AnswerOption(id="a", text="Demokratie"),
+            AnswerOption(id="b", text="Wahl"),
+        ),
+    )
+
+    items = extract_vocabulary(
+        [question],
+        [AnswerKey(question_id="5", correct_option_id="b")],
+    )
+
+    assert [item.word for item in items] == ["wahl"]


### PR DESCRIPTION
Closes #4

## Summary
- add fixture and pinned GitHub structured answer providers
- match answer letters by official id first, then normalized question text
- fail unmatched or invalid matches with audit-friendly diagnostics
- route export through answer matching and verify distractors stay out of vocabulary input

## Verification
- .venv/bin/python -m pytest
- git diff --check