### PR TITLE
Extract normalized vocabulary items

### DIFF
--- a/src/leben_vocab/vocabulary.py
+++ b/src/leben_vocab/vocabulary.py
@@ -1,4 +1,5 @@
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
+import re
 
 from leben_vocab.answers import AnswerKey
 from leben_vocab.corpus import Question
@@ -19,9 +20,36 @@ class VocabularyItem:
         return replace(self, translation=translation)
 
 
+@dataclass(frozen=True)
+class GermanVocabularyNormalizer:
+    verb_lemmas: dict[str, str] = field(default_factory=dict)
+    noun_forms: dict[str, tuple[str | None, str, str | None]] = field(
+        default_factory=lambda: {
+            "demokratie": (None, "Demokratie", None),
+            "wahl": (None, "Wahl", None),
+        }
+    )
+
+    def normalize(self, token: str) -> tuple[str, str, str] | None:
+        normalized = token.lower()
+        verb = self.verb_lemmas.get(normalized)
+        if verb is not None:
+            return verb, "verb", verb
+
+        noun = self.noun_forms.get(normalized)
+        if noun is not None:
+            article, display, plural = noun
+            return normalized, "noun", _format_noun_display(article, display, plural)
+
+        return None
+
+
 def extract_vocabulary(
-    questions: list[Question], answer_keys: list[AnswerKey]
+    questions: list[Question],
+    answer_keys: list[AnswerKey],
+    normalizer: GermanVocabularyNormalizer | None = None,
 ) -> list[VocabularyItem]:
+    normalizer = normalizer or GermanVocabularyNormalizer()
     correct_options = {
         answer.question_id: answer.correct_option_id for answer in answer_keys
     }
@@ -32,32 +60,61 @@ def extract_vocabulary(
         correct_option = next(
             option for option in question.options if option.id == correct_option_id
         )
-        fixture_words = _fixture_words(question.text, correct_option.text)
-        for word in fixture_words:
-            existing = counts.get(word)
-            if existing is None:
-                counts[word] = VocabularyItem(
+        sources = [(question.text, "question")]
+        if correct_option.text and not correct_option.is_image_only:
+            sources.append((correct_option.text, "answer"))
+
+        for text, source in sources:
+            for token in _tokens(text):
+                normalized = normalizer.normalize(token)
+                if normalized is None:
+                    continue
+                word, kind, display = normalized
+                counts[word] = _record_item(
+                    existing=counts.get(word),
                     word=word,
-                    kind="noun",
-                    display=word.capitalize(),
-                    translation="",
-                    example=question.text,
-                    example_source="fixture",
+                    kind=kind,
+                    display=display,
+                    example=text,
+                    example_source=source,
                     question_id=question.id,
-                    count=1,
                 )
-            else:
-                counts[word] = replace(existing, count=existing.count + 1)
 
     return list(counts.values())
 
 
-def _fixture_words(question_text: str, correct_answer_text: str) -> list[str]:
-    texts = [question_text.lower(), correct_answer_text.lower()]
-    words: list[str] = []
-    for text in texts:
-        if "demokratie" in text:
-            words.append("demokratie")
-        if "wahl" in text:
-            words.append("wahl")
-    return words
+def _record_item(
+    existing: VocabularyItem | None,
+    word: str,
+    kind: str,
+    display: str,
+    example: str,
+    example_source: str,
+    question_id: str,
+) -> VocabularyItem:
+    if existing is None:
+        return VocabularyItem(
+            word=word,
+            kind=kind,
+            display=display,
+            translation="",
+            example=example,
+            example_source=example_source,
+            question_id=question_id,
+            count=1,
+        )
+    return replace(existing, count=existing.count + 1)
+
+
+def _tokens(text: str) -> list[str]:
+    return re.findall(r"[A-Za-zÄÖÜäöüß]+", text)
+
+
+def _format_noun_display(
+    article: str | None, display: str, plural: str | None
+) -> str:
+    if article and plural:
+        return f"{article} {display}, {plural}"
+    if article:
+        return f"{article} {display}"
+    return display

--- a/tests/test_vocabulary_extraction.py
+++ b/tests/test_vocabulary_extraction.py
@@ -1,0 +1,103 @@
+from leben_vocab.answers import AnswerKey
+from leben_vocab.corpus import AnswerOption, Question
+from leben_vocab.vocabulary import GermanVocabularyNormalizer, extract_vocabulary
+
+
+def test_extraction_uses_question_text_and_correct_answer_text_only():
+    questions = [
+        Question(
+            id="1",
+            state=None,
+            text="Die Bürger wählen das Parlament.",
+            options=(
+                AnswerOption(id="a", text="die Regierung"),
+                AnswerOption(id="b", text="die Monarchie"),
+            ),
+        )
+    ]
+
+    items = extract_vocabulary(
+        questions,
+        [AnswerKey(question_id="1", correct_option_id="a")],
+        normalizer=GermanVocabularyNormalizer(
+            verb_lemmas={"wählen": "wählen"},
+            noun_forms={
+                "bürger": ("der", "Bürger", "Bürger"),
+                "parlament": ("das", "Parlament", "Parlamente"),
+                "regierung": ("die", "Regierung", "Regierungen"),
+                "monarchie": ("die", "Monarchie", "Monarchien"),
+            },
+        ),
+    )
+
+    assert [(item.word, item.kind, item.display) for item in items] == [
+        ("bürger", "noun", "der Bürger, Bürger"),
+        ("wählen", "verb", "wählen"),
+        ("parlament", "noun", "das Parlament, Parlamente"),
+        ("regierung", "noun", "die Regierung, Regierungen"),
+    ]
+    assert "monarchie" not in {item.word for item in items}
+
+
+def test_extraction_counts_items_and_keeps_one_traceable_example():
+    questions = [
+        Question(
+            id="1",
+            state=None,
+            text="Die Bürger wählen das Parlament.",
+            options=(AnswerOption(id="a", text="die Bürger"),),
+        ),
+        Question(
+            id="2",
+            state=None,
+            text="Viele Bürger lesen.",
+            options=(AnswerOption(id="a", text="das Parlament"),),
+        ),
+    ]
+
+    items = extract_vocabulary(
+        questions,
+        [
+            AnswerKey(question_id="1", correct_option_id="a"),
+            AnswerKey(question_id="2", correct_option_id="a"),
+        ],
+        normalizer=GermanVocabularyNormalizer(
+            verb_lemmas={"wählen": "wählen", "lesen": "lesen"},
+            noun_forms={
+                "bürger": ("der", "Bürger", "Bürger"),
+                "parlament": ("das", "Parlament", "Parlamente"),
+            },
+        ),
+    )
+
+    by_word = {item.word: item for item in items}
+    assert by_word["bürger"].count == 3
+    assert by_word["bürger"].example == "Die Bürger wählen das Parlament."
+    assert by_word["bürger"].example_source == "question"
+    assert by_word["bürger"].question_id == "1"
+
+
+def test_image_only_correct_answer_contributes_no_answer_vocabulary():
+    questions = [
+        Question(
+            id="BE-1",
+            state="Berlin",
+            text="Welches Wappen gehört zum Bundesland Berlin?",
+            options=(AnswerOption(id="a", text="", is_image_only=True),),
+        )
+    ]
+
+    items = extract_vocabulary(
+        questions,
+        [AnswerKey(question_id="BE-1", correct_option_id="a")],
+        normalizer=GermanVocabularyNormalizer(
+            noun_forms={
+                "wappen": (None, "Wappen", None),
+                "bundesland": ("das", "Bundesland", "Bundesländer"),
+                "berlin": (None, "Berlin", None),
+            },
+        ),
+    )
+
+    assert [item.word for item in items] == ["wappen", "bundesland", "berlin"]
+    assert items[0].display == "Wappen"


### PR DESCRIPTION
Closes #5

## Summary
- replace fixture-only word detection with generic extraction from question and correct answer text
- add lightweight German normalization hooks for verb lemmas and noun article/plural display
- count vocabulary items while preserving one traceable example and source question
- ignore incorrect answer options and image-only answer text

## Verification
- .venv/bin/python -m pytest
- git diff --check