### PR TITLE
Add translation routing and cache

### DIFF
--- a/src/leben_vocab/export.py
+++ b/src/leben_vocab/export.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from leben_vocab.answers import FixtureAnswerProvider, match_answer_keys
 from leben_vocab.corpus import FixtureCorpusProvider
 from leben_vocab.csv_export import write_vocabulary_csv
-from leben_vocab.translation import FixtureTranslationProvider
+from leben_vocab.translation import FixtureTranslationProvider, TranslationRouter
 from leben_vocab.vocabulary import extract_vocabulary
 
 
@@ -13,7 +13,7 @@ def export_fixture_vocabulary(
     output_path: Path,
     corpus_provider: FixtureCorpusProvider | None = None,
     answer_provider: FixtureAnswerProvider | None = None,
-    translation_provider: FixtureTranslationProvider | None = None,
+    translation_provider: FixtureTranslationProvider | TranslationRouter | None = None,
 ) -> None:
     corpus_provider = corpus_provider or FixtureCorpusProvider()
     answer_provider = answer_provider or FixtureAnswerProvider()
@@ -22,8 +22,13 @@ def export_fixture_vocabulary(
     questions = corpus_provider.load_questions(state)
     answer_keys = match_answer_keys(questions, answer_provider.load_answer_keys())
     items = extract_vocabulary(questions, answer_keys)
-    translated_items = [
-        item.with_translation(translation_provider.translate(item.word, target_language))
-        for item in items
-    ]
+    if isinstance(translation_provider, TranslationRouter):
+        translated_items = translation_provider.translate_items(items, target_language)
+    else:
+        translated_items = [
+            item.with_translation(
+                translation_provider.translate(item.word, target_language) or ""
+            )
+            for item in items
+        ]
     write_vocabulary_csv(translated_items, target_language, output_path)

--- a/src/leben_vocab/translation.py
+++ b/src/leben_vocab/translation.py
@@ -1,8 +1,95 @@
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+import os
+from typing import Protocol
+
+from leben_vocab.vocabulary import VocabularyItem
+
+
+class TranslationProvider(Protocol):
+    name: str
+
+    def translate(self, word: str, target_language: str) -> str | None:
+        ...
+
+
+class TranslationUnavailableError(RuntimeError):
+    pass
+
+
+@dataclass
+class TranslationCache:
+    _values: dict[tuple[str, str, str, str], str] = field(default_factory=dict)
+
+    def get(
+        self, word: str, kind: str, target_language: str, provider_name: str
+    ) -> str | None:
+        return self._values.get((word, kind, target_language, provider_name))
+
+    def set(
+        self,
+        word: str,
+        kind: str,
+        target_language: str,
+        provider_name: str,
+        translation: str,
+    ) -> None:
+        self._values[(word, kind, target_language, provider_name)] = translation
+
+
+@dataclass
+class TranslationRouter:
+    deepl_provider: TranslationProvider
+    fallback_provider: TranslationProvider
+    cache: TranslationCache = field(default_factory=TranslationCache)
+
+    def translate_item(
+        self, item: VocabularyItem, target_language: str
+    ) -> VocabularyItem:
+        provider = self._provider_for(target_language)
+        cached = self.cache.get(
+            item.word, item.kind, target_language, provider.name
+        )
+        if cached is not None:
+            return item.with_translation(cached)
+
+        translation = provider.translate(item.word, target_language)
+        if not translation:
+            raise TranslationUnavailableError(
+                f"Translation unavailable for {item.word!r} via {provider.name}"
+            )
+
+        self.cache.set(
+            item.word,
+            item.kind,
+            target_language,
+            provider.name,
+            translation,
+        )
+        return item.with_translation(translation)
+
+    def translate_items(
+        self, items: list[VocabularyItem], target_language: str
+    ) -> list[VocabularyItem]:
+        return [self.translate_item(item, target_language) for item in items]
+
+    def _provider_for(self, target_language: str) -> TranslationProvider:
+        if target_language == "en":
+            return self.deepl_provider
+        return self.fallback_provider
+
+
+def load_deepl_api_key(env: Mapping[str, str] | None = None) -> str | None:
+    values = env or os.environ
+    return values.get("DEEPL_API_KEY") or values.get("deepl_api_key")
+
+
 class FixtureTranslationProvider:
+    name = "fixture"
     _translations = {
         ("demokratie", "en"): "democracy",
         ("wahl", "en"): "election",
     }
 
-    def translate(self, word: str, target_language: str) -> str:
+    def translate(self, word: str, target_language: str) -> str | None:
         return self._translations.get((word, target_language), f"{word}-{target_language}")

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1,0 +1,117 @@
+import pytest
+
+from leben_vocab.translation import (
+    TranslationCache,
+    TranslationRouter,
+    TranslationUnavailableError,
+    load_deepl_api_key,
+)
+from leben_vocab.vocabulary import VocabularyItem
+from leben_vocab.export import export_fixture_vocabulary
+
+
+class RecordingProvider:
+    def __init__(self, name, translations):
+        self.name = name
+        self.translations = translations
+        self.calls = []
+
+    def translate(self, word, target_language):
+        self.calls.append((word, target_language))
+        return self.translations.get((word, target_language))
+
+
+def item(word="demokratie", kind="noun"):
+    return VocabularyItem(
+        word=word,
+        kind=kind,
+        display=word,
+        translation="",
+        example="example",
+        example_source="question",
+        question_id="1",
+        count=1,
+    )
+
+
+def test_deepl_api_key_loads_from_env_with_uppercase_precedence():
+    assert load_deepl_api_key({"deepl_api_key": "lower"}) == "lower"
+    assert (
+        load_deepl_api_key(
+            {"DEEPL_API_KEY": "upper", "deepl_api_key": "lower"}
+        )
+        == "upper"
+    )
+
+
+def test_translation_router_sends_english_to_deepl_and_farsi_to_fallback():
+    deepl = RecordingProvider("deepl", {("demokratie", "en"): "democracy"})
+    fallback = RecordingProvider("fallback", {("demokratie", "fa"): "دموکراسی"})
+    router = TranslationRouter(deepl_provider=deepl, fallback_provider=fallback)
+
+    assert router.translate_item(item(), "en").translation == "democracy"
+    assert router.translate_item(item(), "fa").translation == "دموکراسی"
+
+    assert deepl.calls == [("demokratie", "en")]
+    assert fallback.calls == [("demokratie", "fa")]
+
+
+def test_translation_router_sends_other_non_english_languages_to_fallback():
+    deepl = RecordingProvider("deepl", {})
+    fallback = RecordingProvider("fallback", {("wahl", "tr"): "seçim"})
+    router = TranslationRouter(deepl_provider=deepl, fallback_provider=fallback)
+
+    translated = router.translate_item(item(word="wahl"), "tr")
+
+    assert translated.translation == "seçim"
+    assert deepl.calls == []
+    assert fallback.calls == [("wahl", "tr")]
+
+
+def test_translation_cache_key_includes_word_type_language_and_provider():
+    cache = TranslationCache()
+
+    cache.set("wahl", "noun", "en", "deepl", "election")
+
+    assert cache.get("wahl", "noun", "en", "deepl") == "election"
+    assert cache.get("wahl", "verb", "en", "deepl") is None
+    assert cache.get("wahl", "noun", "fa", "deepl") is None
+    assert cache.get("wahl", "noun", "en", "fallback") is None
+
+
+def test_cached_translation_prevents_duplicate_provider_calls():
+    deepl = RecordingProvider("deepl", {("demokratie", "en"): "democracy"})
+    router = TranslationRouter(
+        deepl_provider=deepl,
+        fallback_provider=RecordingProvider("fallback", {}),
+    )
+
+    router.translate_item(item(), "en")
+    router.translate_item(item(), "en")
+
+    assert deepl.calls == [("demokratie", "en")]
+
+
+def test_uncached_unavailable_translation_fails_export():
+    router = TranslationRouter(
+        deepl_provider=RecordingProvider("deepl", {}),
+        fallback_provider=RecordingProvider("fallback", {}),
+    )
+
+    with pytest.raises(TranslationUnavailableError, match="demokratie"):
+        router.translate_item(item(), "en")
+
+
+def test_export_fails_when_required_translation_is_unavailable(tmp_path):
+    router = TranslationRouter(
+        deepl_provider=RecordingProvider("deepl", {}),
+        fallback_provider=RecordingProvider("fallback", {}),
+    )
+
+    with pytest.raises(TranslationUnavailableError, match="demokratie"):
+        export_fixture_vocabulary(
+            state="Berlin",
+            target_language="en",
+            output_path=tmp_path / "words_en.csv",
+            translation_provider=router,
+        )


### PR DESCRIPTION
Closes #6

## Summary
- load DeepL credentials from uppercase/lowercase env names with uppercase precedence
- route English through the DeepL provider and Farsi/other targets through fallback providers
- cache translations by word, type, target language, and provider
- fail routed exports when required translations are unavailable and uncached

## Verification
- .venv/bin/python -m pytest
- git diff --check