### PR TITLE
Harden fixture export CLI contract

### DIFF
--- a/src/leben_vocab/answers.py
+++ b/src/leben_vocab/answers.py
@@ -29,6 +29,7 @@ class FixtureAnswerProvider:
         self._answers = answers or [
             StructuredAnswer(question_id="1", correct_option_id="a"),
             StructuredAnswer(question_id="BE-1", correct_option_id="a"),
+            StructuredAnswer(question_id="BY-1", correct_option_id="a"),
         ]
 
     def load_answer_keys(self) -> list[StructuredAnswer]:

--- a/src/leben_vocab/corpus.py
+++ b/src/leben_vocab/corpus.py
@@ -18,6 +18,7 @@ class Question:
 
 class FixtureCorpusProvider:
     def load_questions(self, state: str) -> list[Question]:
+        state_code = _state_code(state)
         return [
             Question(
                 id="1",
@@ -29,7 +30,7 @@ class FixtureCorpusProvider:
                 ),
             ),
             Question(
-                id="BE-1",
+                id=f"{state_code}-1",
                 state=state,
                 text="Berlin hat ein Parlament.",
                 options=(
@@ -38,3 +39,10 @@ class FixtureCorpusProvider:
                 ),
             ),
         ]
+
+
+def _state_code(state: str) -> str:
+    return {
+        "Bayern": "BY",
+        "Berlin": "BE",
+    }.get(state, state[:2].upper())

--- a/tests/test_cli_export.py
+++ b/tests/test_cli_export.py
@@ -60,3 +60,42 @@ def test_export_command_sorts_fixture_rows_by_count_descending(tmp_path):
         ("demokratie", "2"),
         ("wahl", "1"),
     ]
+
+
+def test_export_command_writes_bayern_farsi_fixture_csv(tmp_path):
+    output_path = tmp_path / "words_fa.csv"
+
+    exit_code = main(
+        [
+            "export",
+            "--state",
+            "Bayern",
+            "--target-lang",
+            "fa",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    assert exit_code == 0
+    with output_path.open(newline="", encoding="utf-8") as csv_file:
+        reader = csv.DictReader(csv_file)
+        rows = list(reader)
+
+    assert reader.fieldnames == [
+        "word",
+        "type",
+        "display",
+        "translation",
+        "example",
+        "example_source",
+        "question_id",
+        "count",
+        "target_language",
+    ]
+    assert [(row["word"], row["count"]) for row in rows] == [
+        ("demokratie", "2"),
+        ("wahl", "1"),
+    ]
+    assert {row["target_language"] for row in rows} == {"fa"}
+    assert rows[-1]["question_id"] == "BY-1"


### PR DESCRIPTION
Closes #7

## Summary
- add CLI smoke coverage for the Bayern/Farsi export command
- keep CSV header, count sorting, and target-language contract pinned across example commands
- make fixture state question ids reflect the selected state so tests cover non-default state routing

## Verification
- .venv/bin/python -m pytest
- git diff --check
- .venv/bin/leben-vocab export --state Berlin --target-lang en --output <tmp>/words_en.csv
- .venv/bin/leben-vocab export --state Bayern --target-lang fa --output <tmp>/words_fa.csv